### PR TITLE
Minor spelling mistake.

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,8 +287,8 @@ First: they should be small. Second: they should be smaller than that.
 
 * Functions should hardly ever be **20 lines long**.
 * Functions should be **transparently obvious**.
-* Each function told a story.
-* Each function led you to a next thing in a compelling order.
+* Each function tells a story.
+* Each function leads you to a next thing in a compelling order.
 
 ## Blocks and Indenting
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Well specified requirements can act as executable tests for our code.
 
 Bad code can bring a company down.
 
-There are not excuses for bad code, no reasons: your boss does not give you time, you want to finish faster to get more backlog's stories finished...
+There are no excuses for bad code, no reasons: your boss does not give you time, you want to finish faster to get more backlog's stories finished...
 
 I will clean it later... **Later equals never**.
 


### PR DESCRIPTION
I have corrected a minor spelling mistake under the section Bad Code in Chapter 1. Changed from "There are not excuses for bad code" to "There are no excuses for bad code".